### PR TITLE
remove section about upstream mentors from teamproposal.html 

### DIFF
--- a/people/2015/spring/wywin.yaml
+++ b/people/2015/spring/wywin.yaml
@@ -21,3 +21,6 @@ hw:
   teamprop0: http://wyattwinters.com/teamprop0.html
   profile0: http://wyattwinters.com/profile0-wordpress.html
   teamprop1: http://wyattwinters.com/teamprop1.html
+  profile1: http://wyattwinters.com/profile1-apache-software-foundation.html
+  teamprop2: http://wyattwinters.com/teamprop2.html
+  litreview8: http://wyattwinters.com/litreview8.html

--- a/static/hw/teamproposal.html
+++ b/static/hw/teamproposal.html
@@ -47,37 +47,6 @@
 <a target="_blank" href="http://github.com/orgname">Example Github Organization URL</a>
 <a target="_blank" href="http://github.com/orgname/reponame">Example Github Repo URL</a>
 
-
-<h2>List your upstream Mentor's below:</h2>
-<table border="1px">
-    <tr>
-        <td>Name</td>
-        <td>email</td>
-        <td>expertise</td>
-    </tr>
-    <tr>
-        <td>One</td>
-        <td>One</td>
-        <td>Jumping</td>
-    </tr>
-    <tr>
-        <td>Two</td>
-        <td>Two</td>
-        <td>Castling</td>
-    </tr>
-    <tr>
-        <td>Three</td>
-        <td>Three</td>
-        <td>Diagonning</td>
-    </tr>
-    <tr>
-        <td>Four</td>
-        <td>Four</td>
-        <td>Passing</td>
-    </tr>
-</table>
-<h2>How will you communicate with them? (i.e. IRC Channel, Email Addresss, mail lists, issue trackers, etc...)</h2>
-
 <h2>What do you anticipate the easy parts will be?</h2>
 <ul>
     <li>ANSWERS</li>


### PR DESCRIPTION
I suspect it was left over from HFOSS, and doesn't quite apply here. Unless we are supposed to actually talk to people at the organizations, in which case I've been doing this wrong the whole time.
