### PR TITLE
Renmaed finalpost to finalanswers

### DIFF
--- a/people/2015/spring/loothelion.yaml
+++ b/people/2015/spring/loothelion.yaml
@@ -35,7 +35,7 @@ hw:
   profile4: http://gearchicken.com/blog/2015/05/13/profile4.html
   preso4: http://gearchicken.com/blog/2015/05/13/preso4.html
   finalquestions: http://gearchicken.com/blog/2015/05/05/questions.html
-  finalpost: http://gearchicken.com/blog/2015/05/13/final-questions.html
+  finalanswers: http://gearchicken.com/blog/2015/05/13/final-questions.html
 coderwall: liam-middlebrook
 twitter: liammiddlebrook
 github: liam-middlebrook


### PR DESCRIPTION
This was originally merged in as #203 but apparently @decause decided to
change what the key should be after accepting some pull requests.
:confused:
